### PR TITLE
Extend click area for row item

### DIFF
--- a/searchdialog/src/main/java/com/ajithvgiri/searchdialog/SearchAdapter.kt
+++ b/searchdialog/src/main/java/com/ajithvgiri/searchdialog/SearchAdapter.kt
@@ -30,6 +30,9 @@ class SearchAdapter(var onSearchItemSelected: OnSearchItemSelected, private var 
             itemView.text1.setOnClickListener {
                 onSearchItemSelected.onClick(position = position, searchListItem = searchListItem)
             }
+            itemView.row.setOnClickListener {
+                onSearchItemSelected.onClick(position = position, searchListItem = searchListItem)
+            }
         }
     }
 }

--- a/searchdialog/src/main/res/layout/items_view_layout.xml
+++ b/searchdialog/src/main/res/layout/items_view_layout.xml
@@ -1,11 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
-<TextView xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/text1"
+<LinearLayout
+    android:id="@+id/row"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:gravity="center|start"
-
-    android:padding="13dp"
-    android:textSize="16sp">
-
-</TextView>
+    android:layout_height="60dp"
+    android:clickable="true"
+    android:focusable="true"
+    android:foreground="?attr/selectableItemBackground"
+    xmlns:android="http://schemas.android.com/apk/res/android">
+    <TextView
+        android:id="@+id/text1"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center|start"
+        android:padding="13dp"
+        android:textSize="16sp">
+    </TextView>
+</LinearLayout>


### PR DESCRIPTION
When the item text view is short, it is hard for users to click in the row. So I extend click area for row item.